### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/StijnVerhoeven-realdolmen/ce238dff-1396-4196-b474-31395ebf950d/14d142fa-fec0-46bc-8e46-c448afae342b/_apis/work/boardbadge/d56583fb-d2f2-427f-a865-488c97806651)](https://dev.azure.com/StijnVerhoeven-realdolmen/ce238dff-1396-4196-b474-31395ebf950d/_boards/board/t/14d142fa-fec0-46bc-8e46-c448afae342b/Microsoft.RequirementCategory)
 # golang-azure
 Learning Golang with Azure Go SDK


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#35](https://dev.azure.com/StijnVerhoeven-realdolmen/ce238dff-1396-4196-b474-31395ebf950d/_workitems/edit/35). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.